### PR TITLE
去除print中的emoji

### DIFF
--- a/qwen_asr_gguf/inference/asr.py
+++ b/qwen_asr_gguf/inference/asr.py
@@ -205,15 +205,15 @@ class QwenASREngine:
         pre_speed = stats["prefill_tokens"] / stats["prefill_time"] if stats["prefill_time"] > 0 else 0
         gen_speed = stats["decode_tokens"] / stats["decode_time"] if stats["decode_time"] > 0 else 0
         
-        print(f"\n\n📊 性能统计:")
-        print(f"  🔹 RTF (实时率) : {rtf:.3f} (越小越快)")
-        print(f"  🔹 音频时长    : {audio_duration:.2f} 秒")
-        print(f"  🔹 总处理耗时  : {t_total:.2f} 秒")
+        print(f"\n\n 性能统计:")
+        print(f"  RTF (实时率) : {rtf:.3f} (越小越快)")
+        print(f"  音频时长    : {audio_duration:.2f} 秒")
+        print(f"  总处理耗时  : {t_total:.2f} 秒")
         if stats.get("align_time"):
-            print(f"  🔹 对齐耗时    : {stats['align_time']:.3f} 秒")
-        print(f"  🔹 编码耗时    : {stats['encode_time']:.3f} 秒")
-        print(f"  🔹 LLM 预填充  : {stats['prefill_time']:.3f} 秒 ({stats['prefill_tokens']} tokens, {pre_speed:.1f} tokens/s)")
-        print(f"  🔹 LLM 生成    : {stats['decode_time']:.3f} 秒 ({stats['decode_tokens']} tokens, {gen_speed:.1f} tokens/s)")
+            print(f"  对齐耗时    : {stats['align_time']:.3f} 秒")
+        print(f"  编码耗时    : {stats['encode_time']:.3f} 秒")
+        print(f"  LLM 预填充  : {stats['prefill_time']:.3f} 秒 ({stats['prefill_tokens']} tokens, {pre_speed:.1f} tokens/s)")
+        print(f"  LLM 生成    : {stats['decode_time']:.3f} 秒 ({stats['decode_tokens']} tokens, {gen_speed:.1f} tokens/s)")
 
     def transcribe(
         self, 

--- a/qwen_asr_gguf/inference/exporters.py
+++ b/qwen_asr_gguf/inference/exporters.py
@@ -92,7 +92,7 @@ def export_to_srt(path: str, result: TranscribeResult):
     content = alignment_to_srt(result.alignment.items)
     with open(path, "w", encoding="utf-8") as f:
         f.write(content)
-    print(f"✅ 已生成字幕文件: {path}")
+    print(f" 已生成字幕文件: {path}")
 
 def export_to_json(path: str, result: TranscribeResult):
     """将对齐结果保存为 JSON 文件"""
@@ -103,7 +103,7 @@ def export_to_json(path: str, result: TranscribeResult):
     data = alignment_to_json(result.alignment.items)
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
-    print(f"✅ 已导出时间戳: {path}")
+    print(f" 已导出时间戳: {path}")
 
 def export_to_txt(path: str, result: TranscribeResult):
     """将转录结果处理后保存为 TXT 文件 (含 ITN 和标点换行)"""
@@ -116,4 +116,4 @@ def export_to_txt(path: str, result: TranscribeResult):
     
     with open(path, "w", encoding="utf-8") as f:
         f.write(formatted_text)
-    print(f"✅ 已保存文本文件: {path}")
+    print(f" 已保存文本文件: {path}")


### PR DESCRIPTION
在Windows上通过其他程序调用的时候，会因为emoji执行失败：

| _asr_gguf\inference\asr.py:236 in _print_stats                              |
|                                                                             |
|   233         pre_speed = stats["prefill_tokens"] / stats["prefill_time"] i |
|   234         gen_speed = stats["decode_tokens"] / stats["decode_time"] if  |
|   235                                                                       |
| > 236         print(f"\n\n\U0001f4ca ����ͳ��:")                                    |
|   237         print(f"  \U0001f539 RTF (ʵʱ��) : {rtf:.3f} (ԽСԽ��)")            |
|   238         print(f"  \U0001f539 ��Ƶʱ��    : {audio_duration:.2f} ��")          |
|   239         print(f"  \U0001f539 �ܴ����ʱ  : {t_total:.2f} ��")                 |
+-----------------------------------------------------------------------------+
UnicodeEncodeError: 'gbk' codec can't encode character '\U0001f4ca' in position
4: illegal multibyte sequence